### PR TITLE
Add deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,76 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-upload:
+    name: Build and Upload
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        working-directory: ./tdp_tool
+
+    strategy:
+      matrix:
+        include:
+          - build: linux
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+
+          - build: macos
+            os: macos-latest
+            target: x86_64-apple-darwin
+
+          - build: windows-gnu
+            os: windows-latest
+            target: x86_64-pc-windows-gnu
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Get the release version from the tag
+        shell: bash
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Build
+        shell: bash
+        run: cargo build --verbose --release --target ${{ matrix.target }}
+
+      - name: Build archive
+        shell: bash
+        run: |
+          binary_name="tdp_tool"
+
+          dirname="$binary_name-${{ env.VERSION }}-${{ matrix.target }}"
+          mkdir "$dirname"
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+           mv "target/${{ matrix.target }}/release/$binary_name.exe" "$dirname"
+          else
+           mv "target/${{ matrix.target }}/release/$binary_name" "$dirname"
+          fi
+          
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+           7z a "$dirname.zip" "$dirname"
+           echo "ASSET=$dirname.zip" >> $GITHUB_ENV
+          else
+           tar -czf "$dirname.tar.gz" "$dirname"
+           echo "ASSET=$dirname.tar.gz" >> $GITHUB_ENV
+          fi
+      - name: Upload the archive
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            tdp_tool/${{ env.ASSET }}
+          


### PR DESCRIPTION
我觉得 对于不熟悉计算机的人来说，有`tdp_tool`的 预编译版本 可能比较方便，所以我写了一个部署的action，它会 在commit有 形如`[0-9]+.[0-9]+.[0-9]+`(e.g. 1.1.4)格式的标签时 自动编译 三大主流平台的 二进制文件，并上传到`release`。

B.T.W. 我在推上的用户名是`@yulingko_`、与岭。（_谓称不要用xioi了这是五年级的时候乱写的谢谢XD_）